### PR TITLE
update requirement.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ jinja2
 chardet
 requests
 pbkdf2
-pycrypto
+pycryptodome


### PR DESCRIPTION
pycrypto已久未更新，[存在安全隐患](https://www.cvedetails.com/vulnerability-list/vendor_id-11993/product_id-22441/Dlitz-Pycrypto.html)。而且[在arm架构下build报错](https://github.com/dlitz/pycrypto/issues/263)。更换成兼容的[pycrytodome](https://github.com/Legrandin/pycryptodome)，在arm32v7, arm64v8以及现有的amd64下测试无问题。